### PR TITLE
perf(auth): use faster session getter

### DIFF
--- a/pages/api/auth/[...nextauth].tsx
+++ b/pages/api/auth/[...nextauth].tsx
@@ -1,4 +1,4 @@
-import NextAuth from "next-auth"
+import NextAuth, { NextAuthOptions } from "next-auth"
 import GithubProvider from "next-auth/providers/github"
 import GoogleProvider from "next-auth/providers/google";
 import { MongoDBAdapter } from "@next-auth/mongodb-adapter"
@@ -8,7 +8,7 @@ import config from "../../../config"
 
 const { github, google } = config.oauth;
 
-export default NextAuth({
+export const authOptions: NextAuthOptions = {
   adapter: MongoDBAdapter(db.connect()),
   providers: [
     GithubProvider({
@@ -24,5 +24,7 @@ export default NextAuth({
     signIn: '/auth/sign-in',
     signOut: '/auth/sign-out',
   },
-})
+};
+
+export default NextAuth(authOptions);
 

--- a/pages/auth/profile.tsx
+++ b/pages/auth/profile.tsx
@@ -1,11 +1,14 @@
 import { GetServerSideProps, GetServerSidePropsContext, InferGetServerSidePropsType, NextPage } from 'next';
-import { BasePageLayout } from '../../components/layouts/BasePageLayout';
-import { Avatar, Button, Typography } from '@mui/material';
-import { getSession, signOut } from 'next-auth/react';
 import { FC } from 'react';
-import { Session } from 'next-auth';
-import { IUser } from '../../interfaces/users';
 import Image from 'next/image';
+
+import { signOut } from 'next-auth/react';
+import { unstable_getServerSession } from 'next-auth';
+import { Avatar, Button, Typography } from '@mui/material';
+
+import { authOptions } from '../api/auth/[...nextauth]';
+import { BasePageLayout } from '../../components/layouts/BasePageLayout';
+import { IUser } from '../../interfaces/users';
 
 interface PageProps {
   user: IUser,
@@ -100,7 +103,7 @@ export const ProfilePageContent: FC<PageProps> = ({ user }) => {
 
 
 export const getServerSideProps: GetServerSideProps<PageProps> = async (context: GetServerSidePropsContext) => {
-  const session = await getSession(context);
+  const session = await unstable_getServerSession(context.req, context.res, authOptions);
   if (!session) {
     return {
       redirect: {

--- a/pages/auth/sign-in.tsx
+++ b/pages/auth/sign-in.tsx
@@ -1,10 +1,13 @@
 import { GetServerSideProps, GetServerSidePropsContext, NextPage } from "next";
-import { getProviders, getSession, signIn } from "next-auth/react"
-import { Button, Typography } from '@mui/material';
 import { FC } from 'react';
-import { BasePageLayout } from "../../components/layouts";
+
+import { getProviders, signIn } from "next-auth/react"
+import { Button, Typography } from '@mui/material';
+import { unstable_getServerSession } from 'next-auth';
 import { GitHub, Google } from "@mui/icons-material";
-import { Session } from "next-auth";
+
+import { BasePageLayout } from "../../components/layouts";
+import { authOptions } from '../api/auth/[...nextauth]';
 
 type ClientSafeProviders = Awaited<ReturnType<typeof getProviders>>;
 
@@ -77,7 +80,7 @@ const SignInPageContent: FC<PageProps> = ({ providers }) => {
 }
 
 export const getServerSideProps: GetServerSideProps<PageProps> = async (context: GetServerSidePropsContext) => {
-  const session = await getSession(context);
+  const session = await unstable_getServerSession(context.req, context.res, authOptions);
   if (session) {
     return {
       redirect: {


### PR DESCRIPTION
## Details

According to [`unstable_getServerSession`](https://next-auth.js.org/configuration/nextjs#unstable_getserversession), it is a faster method to retrieve the session instead of `getSession`.