### PR TITLE
feat(equivalence): display groups list

### DIFF
--- a/components/ui/EquivalenceGroupCard.tsx
+++ b/components/ui/EquivalenceGroupCard.tsx
@@ -1,0 +1,35 @@
+import { FC } from "react";
+
+import { Card, CardActionArea, CardContent, SxProps, Theme, Typography } from "@mui/material"
+
+import { IPaymentGroup } from "../../interfaces/payment-group";
+
+const baseSx: SxProps<Theme> = {};
+
+interface Props {
+  group: IPaymentGroup;
+  sx?: SxProps<Theme>;
+}
+
+export const EquivalenceGroupCard: FC<Props> = ({ group, sx = {} }) => {
+  const { name, payments } = group;
+  return (
+    <Card
+      sx={{
+        ...baseSx,
+        ...sx,
+      }}
+    >
+      <CardActionArea>
+        <CardContent>
+          <Typography variant="h5" component="h2">
+            {name}
+          </Typography>
+          <Typography variant="body1" component="p">
+            Payments: {payments.length}
+          </Typography>
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  )
+}

--- a/components/ui/EquivalenceGroupsList.tsx
+++ b/components/ui/EquivalenceGroupsList.tsx
@@ -1,0 +1,36 @@
+import { FC } from 'react';
+
+import { Grid } from "@mui/material";
+
+import { IPaymentGroup } from "../../interfaces/payment-group";
+import { EquivalenceGroupCard } from './EquivalenceGroupCard';
+
+interface Props {
+  groups: IPaymentGroup[];
+}
+
+export const EquivalenceGroupsList: FC<Props> = ({ groups }) => {
+  return (
+    <Grid container spacing={2} px={5} pb={8}>
+      {groups.map((group) => (
+        <Grid
+          key={group._id}
+          item
+          xs={12}
+          sm={6}
+          md={4}
+        >
+          <EquivalenceGroupCard
+            group={group}
+            sx={{
+              width: "100%",
+              height: "100%",
+              display: "flex",
+              alignItems: "center",
+            }}
+          />
+        </Grid>
+      ))}
+    </Grid>
+  )
+}

--- a/context/equivalence-groups/EquivalenceGroupsProvider.tsx
+++ b/context/equivalence-groups/EquivalenceGroupsProvider.tsx
@@ -4,6 +4,10 @@ import { EquivalenceGroupsState, INITIAL_STATE } from './state';
 import { EquivalenceGroupsAction } from './actions';
 import { reducer } from './reducer';
 import { EquivalenceGroupsContext } from './context';
+import httpClient from '../../apis/_client';
+import { IPaymentGroupsPage } from '../../interfaces/payment-group';
+import { PaginationParams } from '../../interfaces/pagination-params';
+import { buildQueryString } from '../../utils/url';
 
 interface Props {
   children: ReactNode;
@@ -15,10 +19,32 @@ export const EquivalenceGroupsProvider: FC<Props> = ({ children }) => {
     INITIAL_STATE,
   );
 
+  const getGroups = async (paginationParams: PaginationParams) => {
+    dispatch({
+      type: '[EquivalenceGroups] Loading',
+    });
+    try {
+      const queryString = buildQueryString(paginationParams);
+      const response = await httpClient.get<IPaymentGroupsPage>(
+        `/equivalent-value/groups?${queryString}`,
+      );
+      dispatch({
+        type: '[EquivalenceGroups] Loaded',
+        groupsPage: response.data,
+      });
+    } catch (e) {
+      dispatch({
+        type: '[EquivalenceGroups] Failed Load',
+        error: { code: 'unexpected' },
+      });
+    }
+  };
+
   return (
     <EquivalenceGroupsContext.Provider
       value={{
         ...state,
+        getGroups,
       }}
     >
       {children}

--- a/context/equivalence-groups/EquivalenceGroupsProvider.tsx
+++ b/context/equivalence-groups/EquivalenceGroupsProvider.tsx
@@ -1,0 +1,27 @@
+import { ReactNode, FC, useReducer, Reducer } from 'react';
+
+import { EquivalenceGroupsState, INITIAL_STATE } from './state';
+import { EquivalenceGroupsAction } from './actions';
+import { reducer } from './reducer';
+import { EquivalenceGroupsContext } from './context';
+
+interface Props {
+  children: ReactNode;
+}
+
+export const EquivalenceGroupsProvider: FC<Props> = ({ children }) => {
+  const [state, dispatch] = useReducer<Reducer<EquivalenceGroupsState, EquivalenceGroupsAction>>(
+    reducer,
+    INITIAL_STATE,
+  );
+
+  return (
+    <EquivalenceGroupsContext.Provider
+      value={{
+        ...state,
+      }}
+    >
+      {children}
+    </EquivalenceGroupsContext.Provider>
+  );
+}

--- a/context/equivalence-groups/actions.ts
+++ b/context/equivalence-groups/actions.ts
@@ -1,0 +1,22 @@
+import { IPaymentGroup } from '../../interfaces/payment-group';
+import { LoadGroupsError } from './errors';
+
+type LoadingGroupsAction = {
+  type: '[EquivalenceGroups] Loading';
+};
+
+type LoadedGroupsAction = {
+  type: '[EquivalenceGroups] Loaded';
+  groups: IPaymentGroup[];
+};
+
+type FailedLoadGroupsAction = {
+  type: '[EquivalenceGroups] Failed Load';
+  error: LoadGroupsError;
+};
+
+export type EquivalenceGroupsAction =
+  | LoadingGroupsAction
+  | LoadedGroupsAction
+  | FailedLoadGroupsAction
+  ;

--- a/context/equivalence-groups/actions.ts
+++ b/context/equivalence-groups/actions.ts
@@ -1,4 +1,4 @@
-import { IPaymentGroup } from '../../interfaces/payment-group';
+import { IPaymentGroupsPage } from '../../interfaces/payment-group';
 import { LoadGroupsError } from './errors';
 
 type LoadingGroupsAction = {
@@ -7,7 +7,7 @@ type LoadingGroupsAction = {
 
 type LoadedGroupsAction = {
   type: '[EquivalenceGroups] Loaded';
-  groups: IPaymentGroup[];
+  groupsPage: IPaymentGroupsPage;
 };
 
 type FailedLoadGroupsAction = {

--- a/context/equivalence-groups/context.ts
+++ b/context/equivalence-groups/context.ts
@@ -1,8 +1,13 @@
-import { EquivalenceGroupsState } from './state';
 import { createContext, useContext } from 'react';
+
+import { EquivalenceGroupsState } from './state';
+import { PaginationParams } from '../../interfaces/pagination-params';
 
 type CtxProps =
   & EquivalenceGroupsState
+  & {
+    getGroups: (paginationParams: PaginationParams) => Promise<void>;
+  }
   ;
 
 export const EquivalenceGroupsContext = createContext<CtxProps>({} as CtxProps);

--- a/context/equivalence-groups/context.ts
+++ b/context/equivalence-groups/context.ts
@@ -1,0 +1,9 @@
+import { EquivalenceGroupsState } from './state';
+import { createContext, useContext } from 'react';
+
+type CtxProps =
+  & EquivalenceGroupsState
+  ;
+
+export const EquivalenceGroupsContext = createContext<CtxProps>({} as CtxProps);
+export const useEquivalenceGroupsContext = () => useContext<CtxProps>(EquivalenceGroupsContext);

--- a/context/equivalence-groups/errors.ts
+++ b/context/equivalence-groups/errors.ts
@@ -1,0 +1,7 @@
+type UnexpectedError = {
+  code: 'unexpected';
+};
+
+export type LoadGroupsError =
+  | UnexpectedError
+  ;

--- a/context/equivalence-groups/reducer.ts
+++ b/context/equivalence-groups/reducer.ts
@@ -1,0 +1,30 @@
+import { Reducer } from 'react';
+
+import { EquivalenceGroupsState } from './state';
+import { EquivalenceGroupsAction } from './actions';
+
+export const reducer: Reducer<EquivalenceGroupsState, EquivalenceGroupsAction> = (state, action) => {
+  switch (action.type) {
+    case '[EquivalenceGroups] Loading': {
+      return {
+        ...state,
+        loading: true,
+        error: undefined,
+      };
+    }
+    case '[EquivalenceGroups] Loaded': {
+      return {
+        loading: false,
+        groups: action.groups,
+        error: undefined,
+      };
+    }
+    case '[EquivalenceGroups] Failed Load': {
+      return {
+        loading: false,
+        groups: undefined,
+        error: action.error,
+      };
+    }
+  }
+}

--- a/context/equivalence-groups/reducer.ts
+++ b/context/equivalence-groups/reducer.ts
@@ -15,14 +15,14 @@ export const reducer: Reducer<EquivalenceGroupsState, EquivalenceGroupsAction> =
     case '[EquivalenceGroups] Loaded': {
       return {
         loading: false,
-        groups: action.groups,
+        groupsPage: action.groupsPage,
         error: undefined,
       };
     }
     case '[EquivalenceGroups] Failed Load': {
       return {
         loading: false,
-        groups: undefined,
+        groupsPage: undefined,
         error: action.error,
       };
     }

--- a/context/equivalence-groups/reducer.ts
+++ b/context/equivalence-groups/reducer.ts
@@ -7,8 +7,8 @@ export const reducer: Reducer<EquivalenceGroupsState, EquivalenceGroupsAction> =
   switch (action.type) {
     case '[EquivalenceGroups] Loading': {
       return {
-        ...state,
         loading: true,
+        groupsPage: undefined,
         error: undefined,
       };
     }

--- a/context/equivalence-groups/reducer.ts
+++ b/context/equivalence-groups/reducer.ts
@@ -7,8 +7,8 @@ export const reducer: Reducer<EquivalenceGroupsState, EquivalenceGroupsAction> =
   switch (action.type) {
     case '[EquivalenceGroups] Loading': {
       return {
+        ...state,
         loading: true,
-        groupsPage: undefined,
         error: undefined,
       };
     }

--- a/context/equivalence-groups/state.ts
+++ b/context/equivalence-groups/state.ts
@@ -1,0 +1,12 @@
+import { IPaymentGroup } from '../../interfaces/payment-group';
+import { LoadGroupsError } from './errors';
+
+export interface EquivalenceGroupsState {
+  loading: boolean;
+  groups?: IPaymentGroup[];
+  error?: LoadGroupsError;
+}
+
+export const INITIAL_STATE: EquivalenceGroupsState = {
+  loading: false,
+};

--- a/context/equivalence-groups/state.ts
+++ b/context/equivalence-groups/state.ts
@@ -1,9 +1,9 @@
-import { IPaymentGroup } from '../../interfaces/payment-group';
+import { IPaymentGroup, IPaymentGroupsPage } from '../../interfaces/payment-group';
 import { LoadGroupsError } from './errors';
 
 export interface EquivalenceGroupsState {
   loading: boolean;
-  groups?: IPaymentGroup[];
+  groupsPage?: IPaymentGroupsPage;
   error?: LoadGroupsError;
 }
 

--- a/interfaces/pagination-params.ts
+++ b/interfaces/pagination-params.ts
@@ -1,0 +1,4 @@
+export interface PaginationParams {
+  offset?: number;
+  limit?: number;
+}

--- a/interfaces/payment-group.ts
+++ b/interfaces/payment-group.ts
@@ -6,3 +6,9 @@ export type IPaymentGroup = z.infer<typeof PaymentGroupValidationSchema>;
 export type INewPaymentGroup = z.infer<typeof NewPaymentGroupValidationSchema>;
 
 export type IPaymentGroupWithOptionalInterest = z.infer<typeof PaymentGroupWithOptionalInterestValidationSchema>;
+
+export type IPaymentGroupsPage = {
+  groups: IPaymentGroup[];
+  count: number;
+};
+

--- a/pages/api/equivalent-value/groups.ts
+++ b/pages/api/equivalent-value/groups.ts
@@ -4,7 +4,7 @@ import { unstable_getServerSession } from 'next-auth';
 
 import { MethodNotAllowedResponse } from '../../../interfaces/api/method-not-allowed-response';
 import { NewPaymentGroupValidationSchema } from '../../../validation-schemas/payment-group';
-import { INewPaymentGroup, IPaymentGroup } from '../../../interfaces/payment-group';
+import { IPaymentGroup, IPaymentGroupsPage } from '../../../interfaces/payment-group';
 import { BadRequestWithInvalidDataResponse } from '../../../interfaces/api/bad-request-response';
 import { authOptions } from '../auth/[...nextauth]';
 import { UnauthorizedResponse } from '../../../interfaces/api/unauthorized-response';
@@ -17,15 +17,23 @@ type CreateEquivalentValueGroup =
   | IPaymentGroup
   ;
 
+type GetEquivalentValueGroups =
+  | UnauthorizedResponse
+  | IPaymentGroupsPage
+  ;
+
 type Data =
   | MethodNotAllowedResponse
   | CreateEquivalentValueGroup
+  | GetEquivalentValueGroups
   ;
 
 export default function (req: NextApiRequest, res: NextApiResponse<Data>) {
   switch (req.method) {
     case 'POST':
       return createGroup(req, res);
+    case 'GET':
+      return getGroups(req, res);
   }
   return res.status(405).json({ message: 'Method Not Allowed' });
 }
@@ -48,4 +56,24 @@ const createGroup = async (req: NextApiRequest, res: NextApiResponse<CreateEquiv
   await db.connect();
   const newPaymentGroup = await PaymentGroupModel.create(paymentGroup);
   return res.status(201).json(newPaymentGroup.toJSON());
+}
+
+const getGroups = async (req: NextApiRequest, res: NextApiResponse<GetEquivalentValueGroups>) => {
+  const session = await unstable_getServerSession(req, res, authOptions);
+  if (!session) return res.status(401).send({ message: 'Unauthorized' });
+  const filter = { owner: session.userId };
+  const query = req.query;
+  const offset = query.offset ? parseInt(`${query.offset}`) : 0;
+  const limit = query.limit ? parseInt(`${query.limit}`) : 25;
+  if (isNaN(offset) || isNaN(limit) || offset < 0 || limit < 1) {
+    return res.status(400).json({ message: 'Invalid pagination parameters' });
+  }
+  const [groups, groupsCount] = await Promise.all([
+    PaymentGroupModel.find(filter).skip(offset).limit(limit),
+    PaymentGroupModel.countDocuments(filter),
+  ]);
+  return res.status(200).json({
+    groups: groups.map(g => g.toJSON()),
+    count: groupsCount,
+  });
 }

--- a/pages/api/equivalent-value/groups/index.ts
+++ b/pages/api/equivalent-value/groups/index.ts
@@ -2,14 +2,14 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 
 import { unstable_getServerSession } from 'next-auth';
 
-import { MethodNotAllowedResponse } from '../../../interfaces/api/method-not-allowed-response';
-import { NewPaymentGroupValidationSchema } from '../../../validation-schemas/payment-group';
-import { IPaymentGroup, IPaymentGroupsPage } from '../../../interfaces/payment-group';
-import { BadRequestWithInvalidDataResponse } from '../../../interfaces/api/bad-request-response';
-import { authOptions } from '../auth/[...nextauth]';
-import { UnauthorizedResponse } from '../../../interfaces/api/unauthorized-response';
-import { db } from '../../../database';
-import { PaymentGroupModel } from '../../../database/models/payment-group';
+import { MethodNotAllowedResponse } from '../../../../interfaces/api/method-not-allowed-response';
+import { NewPaymentGroupValidationSchema } from '../../../../validation-schemas/payment-group';
+import { IPaymentGroup, IPaymentGroupsPage } from '../../../../interfaces/payment-group';
+import { BadRequestWithInvalidDataResponse } from '../../../../interfaces/api/bad-request-response';
+import { authOptions } from '../../auth/[...nextauth]';
+import { UnauthorizedResponse } from '../../../../interfaces/api/unauthorized-response';
+import { db } from '../../../../database';
+import { PaymentGroupModel } from '../../../../database/models/payment-group';
 
 type CreateEquivalentValueGroup =
   | UnauthorizedResponse

--- a/pages/api/equivalent-value/groups/seed.ts
+++ b/pages/api/equivalent-value/groups/seed.ts
@@ -1,0 +1,49 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { unstable_getServerSession } from 'next-auth';
+import { db } from '../../../../database';
+
+import { MethodNotAllowedResponse } from '../../../../interfaces/api/method-not-allowed-response';
+import { authOptions } from '../../auth/[...nextauth]';
+import { PaymentGroupModel } from '../../../../database/models/payment-group';
+import { INewPaymentGroup } from '../../../../interfaces/payment-group';
+import { UnauthorizedResponse } from '../../../../interfaces/api/unauthorized-response';
+
+type SeedGroups =
+  | UnauthorizedResponse
+  | { success: boolean; }
+  ;
+
+type Data =
+  | MethodNotAllowedResponse
+  | SeedGroups
+  ;
+
+export default function (req: NextApiRequest, res: NextApiResponse<Data>) {
+  switch (req.method) {
+    case 'POST':
+      if (process.env.NODE_ENV === 'production') {
+        return res.status(405).json({ message: 'Method not allowed' });
+      }
+      return seedGroups(req, res);
+  }
+  return res.status(405).json({ message: 'Method not allowed' });
+}
+
+const seedGroups = async (req: NextApiRequest, res: NextApiResponse<Data>) => {
+  const session = await unstable_getServerSession(req, res, authOptions);
+  if (!session) return res.status(401).send({ message: 'Unauthorized' });
+  await db.connect();
+  await PaymentGroupModel.deleteMany();
+  const count = req.body.count;
+  for (let index = 1; index <= count; index++) {
+    const name = `G-${index}`.padStart(3, '0');
+    const paymentGroup: (INewPaymentGroup & { owner: string }) = {
+      name,
+      interest: 5.0,
+      payments: [],
+      owner: session.userId as string,
+    };
+    await PaymentGroupModel.create(paymentGroup);
+  }
+  return res.status(201).json({ message: 'Done' });
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,28 +1,10 @@
 import type { NextPage } from 'next'
 
-import { Typography, Button } from '@mui/material';
+import { Typography } from '@mui/material';
 
 import { BasePageLayout } from '../components/layouts';
-import httpClient from '../apis/_client';
 
 const HomePage: NextPage = () => {
-  const onClick = () => {
-    httpClient.post(
-      '/equivalent-value/groups',
-      {
-        name: "A payment group",
-        interest: 1.2,
-        payments: [
-          {
-            type: "single",
-            name: "A single payment",
-            position: 0,
-            amount: 1.0,
-          },
-        ],
-      },
-    );
-  };
   return (
     <BasePageLayout>
       <Typography
@@ -31,11 +13,6 @@ const HomePage: NextPage = () => {
       >
         Welcome to Letsy!
       </Typography>
-      <Button
-        onClick={onClick}
-      >
-        TEST
-      </Button>
     </BasePageLayout >
   )
 }

--- a/pages/tools/equivalent-value/index.tsx
+++ b/pages/tools/equivalent-value/index.tsx
@@ -119,13 +119,29 @@ const EquivalentValueGroupsPageContent = () => {
               justifyContent="space-between"
             >
               {pagination}
-              <EquivalenceGroupsList groups={groupsPage.groups} />
-              {pagination}
+              {
+                loading
+                  ? (
+                    <Box sx={{ p: { xs: 'auto', sm: 2 } }}>
+                      <Typography variant="h5" textAlign="center">
+                        Loading
+                      </Typography>
+                    </Box>
+                  )
+                  : (
+                    <>
+                      <EquivalenceGroupsList groups={groupsPage.groups} />
+                      {pagination}
+                    </>
+                  )
+              }
             </Stack>
           );
         })()
       }
-      {loading &&
+      {
+        loading &&
+        !groupsPage &&
         <Box sx={{ p: { xs: 'auto', sm: 2 } }}>
           <Typography variant="h5" textAlign="center">
             Loading

--- a/pages/tools/equivalent-value/index.tsx
+++ b/pages/tools/equivalent-value/index.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 import React, { useEffect, useMemo } from 'react';
 
 import { unstable_getServerSession } from 'next-auth';
-import { Box, Typography, Stack, Pagination, PaginationItem } from '@mui/material';
+import { Box, Typography, Stack, Pagination, Button } from '@mui/material';
 
 import { BasePageLayout } from '../../../components/layouts/BasePageLayout';
 import { authOptions } from '../../api/auth/[...nextauth]';
@@ -12,6 +12,7 @@ import { EquivalentValueGroupsProvider } from '../../../context/equivalent-value
 import { EquivalenceGroupsProvider } from '../../../context/equivalence-groups/EquivalenceGroupsProvider';
 import { useEquivalenceGroupsContext } from '../../../context/equivalence-groups/context';
 import { EquivalenceGroupsList } from '../../../components/ui/EquivalenceGroupsList';
+import httpClient from '../../../apis/_client';
 
 const EquivalentValueGroupsPage: NextPage = () => {
   return (
@@ -59,9 +60,43 @@ const EquivalentValueGroupsPageContent = () => {
         height: '100%',
       }}
     >
-      <Typography sx={{ mx: 5, my: 2 }} variant="h5">
-        Groups
-      </Typography>
+      <Stack
+        direction="row"
+        alignItems="center"
+        spacing={2}
+        sx={{ mx: 5, my: 2 }}
+      >
+        <Typography
+          sx={{
+            typography: {
+              xs: 'h5',
+              sm: 'h4',
+            }
+          }}
+        >
+          Groups
+        </Typography>
+        {
+          (process.env.NODE_ENV !== 'production') &&
+          <Button
+            size="small"
+            sx={{
+              px: 3,
+            }}
+            onClick={async () => {
+              await httpClient.post(
+                'equivalent-value/groups/seed',
+                {
+                  count: 200,
+                },
+              );
+              router.reload();
+            }}
+          >
+            Seed groups
+          </Button>
+        }
+      </Stack>
       {groupsPage &&
         (() => {
           const currentPage = Math.ceil((offset + 1) / limit);

--- a/pages/tools/equivalent-value/index.tsx
+++ b/pages/tools/equivalent-value/index.tsx
@@ -1,13 +1,17 @@
 import { NextPage, GetServerSideProps, GetServerSidePropsContext } from 'next';
-import React, { FC, useState, useMemo } from 'react';
+import { useRouter } from 'next/router';
+import React, { useEffect } from 'react';
 
 import { unstable_getServerSession } from 'next-auth';
+import { Box, Typography } from '@mui/material';
 
 import { BasePageLayout } from '../../../components/layouts/BasePageLayout';
 import { authOptions } from '../../api/auth/[...nextauth]';
 import { AddPaymentGroupButton } from '../../../components/ui/AddPaymentGroupButton';
 import { EquivalentValueGroupsProvider } from '../../../context/equivalent-value-groups/EquivalentValueGroupsProvider';
 import { EquivalenceGroupsProvider } from '../../../context/equivalence-groups/EquivalenceGroupsProvider';
+import { useEquivalenceGroupsContext } from '../../../context/equivalence-groups/context';
+import { EquivalenceGroupsList } from '../../../components/ui/EquivalenceGroupsList';
 
 const EquivalentValueGroupsPage: NextPage = () => {
   return (
@@ -16,7 +20,9 @@ const EquivalentValueGroupsPage: NextPage = () => {
         <BasePageLayout
           title="Equivalent Value Calculation - Groups"
           description="Payment groups"
+          displayFooter={false}
         >
+          <EquivalentValueGroupsPageContent />
           <AddPaymentGroupButton />
         </BasePageLayout>
       </EquivalentValueGroupsProvider>
@@ -24,6 +30,51 @@ const EquivalentValueGroupsPage: NextPage = () => {
   );
 }
 export default EquivalentValueGroupsPage;
+
+const EquivalentValueGroupsPageContent = () => {
+  const router = useRouter();
+  const query = router.query;
+  const offset: number = parseInt(`${query.offset}`);
+  const limit: number = parseInt(`${query.limit}`);
+  const { loading, groupsPage, error, getGroups } = useEquivalenceGroupsContext();
+  useEffect(
+    () => {
+      getGroups({
+        offset: isNaN(offset) ? undefined : offset,
+        limit: isNaN(limit) ? undefined : limit,
+      });
+    },
+    [offset, limit],
+  );
+
+  return (
+    <Box
+      sx={{
+        height: '100%',
+      }}
+    >
+      <Typography sx={{ mx: 5, my: 2 }} variant="h5">
+        Groups
+      </Typography>
+      {/* <Divider /> */}
+      {groupsPage &&
+        <EquivalenceGroupsList groups={groupsPage.groups} />
+      }
+      {loading &&
+        <Box sx={{ p: { xs: 'auto', sm: 2 } }}>
+          <Typography variant="h5" textAlign="center">
+            Loading
+          </Typography>
+        </Box>
+      }
+      {error &&
+        <Typography variant="h5" textAlign="center">
+          {error.code}
+        </Typography>
+      }
+    </Box>
+  );
+}
 
 export const getServerSideProps: GetServerSideProps = async (context: GetServerSidePropsContext) => {
   const session = await unstable_getServerSession(context.req, context.res, authOptions);

--- a/pages/tools/equivalent-value/index.tsx
+++ b/pages/tools/equivalent-value/index.tsx
@@ -58,6 +58,7 @@ const EquivalentValueGroupsPageContent = () => {
     <Box
       sx={{
         height: '100%',
+        width: '100%',
       }}
     >
       <Stack

--- a/pages/tools/equivalent-value/index.tsx
+++ b/pages/tools/equivalent-value/index.tsx
@@ -1,9 +1,9 @@
 import { NextPage, GetServerSideProps, GetServerSidePropsContext } from 'next';
 import { useRouter } from 'next/router';
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 
 import { unstable_getServerSession } from 'next-auth';
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, Stack, Pagination, PaginationItem } from '@mui/material';
 
 import { BasePageLayout } from '../../../components/layouts/BasePageLayout';
 import { authOptions } from '../../api/auth/[...nextauth]';
@@ -34,15 +34,21 @@ export default EquivalentValueGroupsPage;
 const EquivalentValueGroupsPageContent = () => {
   const router = useRouter();
   const query = router.query;
-  const offset: number = parseInt(`${query.offset}`);
-  const limit: number = parseInt(`${query.limit}`);
+  const { offset, limit } = useMemo(
+    () => {
+      const unsafeOffset = parseInt(`${query.offset}`);
+      const unsafeLimit = parseInt(`${query.limit}`);
+      return {
+        offset: isNaN(unsafeOffset) ? 0 : unsafeOffset,
+        limit: isNaN(unsafeLimit) ? 50 : unsafeLimit,
+      };
+    },
+    [query],
+  );
   const { loading, groupsPage, error, getGroups } = useEquivalenceGroupsContext();
   useEffect(
     () => {
-      getGroups({
-        offset: isNaN(offset) ? undefined : offset,
-        limit: isNaN(limit) ? undefined : limit,
-      });
+      getGroups({ offset, limit });
     },
     [offset, limit],
   );
@@ -56,9 +62,32 @@ const EquivalentValueGroupsPageContent = () => {
       <Typography sx={{ mx: 5, my: 2 }} variant="h5">
         Groups
       </Typography>
-      {/* <Divider /> */}
       {groupsPage &&
-        <EquivalenceGroupsList groups={groupsPage.groups} />
+        (() => {
+          const currentPage = Math.ceil((offset + 1) / limit);
+          const maxPage = Math.ceil(groupsPage.count / limit);
+          const pagination = (
+            <Pagination
+              page={currentPage}
+              count={maxPage}
+              onChange={(e, value) => {
+                const newOffset = (value - 1) * limit;
+                router.push(`equivalent-value?offset=${newOffset}&limit=${limit}`);
+              }}
+            />
+          );
+          return (
+            <Stack
+              spacing={2}
+              alignItems="center"
+              justifyContent="space-between"
+            >
+              {pagination}
+              <EquivalenceGroupsList groups={groupsPage.groups} />
+              {pagination}
+            </Stack>
+          );
+        })()
       }
       {loading &&
         <Box sx={{ p: { xs: 'auto', sm: 2 } }}>

--- a/pages/tools/equivalent-value/index.tsx
+++ b/pages/tools/equivalent-value/index.tsx
@@ -7,17 +7,20 @@ import { BasePageLayout } from '../../../components/layouts/BasePageLayout';
 import { authOptions } from '../../api/auth/[...nextauth]';
 import { AddPaymentGroupButton } from '../../../components/ui/AddPaymentGroupButton';
 import { EquivalentValueGroupsProvider } from '../../../context/equivalent-value-groups/EquivalentValueGroupsProvider';
+import { EquivalenceGroupsProvider } from '../../../context/equivalence-groups/EquivalenceGroupsProvider';
 
 const EquivalentValueGroupsPage: NextPage = () => {
   return (
-    <EquivalentValueGroupsProvider>
-      <BasePageLayout
-        title="Equivalent Value Calculation - Groups"
-        description="Payment groups"
-      >
-        <AddPaymentGroupButton />
-      </BasePageLayout>
-    </EquivalentValueGroupsProvider>
+    <EquivalenceGroupsProvider>
+      <EquivalentValueGroupsProvider>
+        <BasePageLayout
+          title="Equivalent Value Calculation - Groups"
+          description="Payment groups"
+        >
+          <AddPaymentGroupButton />
+        </BasePageLayout>
+      </EquivalentValueGroupsProvider>
+    </EquivalenceGroupsProvider>
   );
 }
 export default EquivalentValueGroupsPage;

--- a/utils/url.ts
+++ b/utils/url.ts
@@ -1,0 +1,9 @@
+const buildQueryString = (obj: Object) =>
+  Object.entries(obj)
+    .filter(pair => pair[1] != undefined)
+    .map(pair => pair.map(encodeURIComponent).join('='))
+    .join('&');
+
+export {
+  buildQueryString,
+};


### PR DESCRIPTION
## Details

- Display the list of payments groups used for equivalence calculation.
- Filter by authenticated user.
- Use pagination.