### PR TITLE
fix(eq-group): use proper initial interest

### DIFF
--- a/context/equivalent-value-groups/EquivalentValueGroupsProvider.tsx
+++ b/context/equivalent-value-groups/EquivalentValueGroupsProvider.tsx
@@ -32,7 +32,7 @@ export const EquivalentValueGroupsProvider: FC<Props> = ({ children }) => {
     try {
       const newGroup: INewPaymentGroup = {
         name,
-        interest: 5.0,
+        interest: 0.05,
         payments: [],
       };
       const response = await httpClient.post<IPaymentGroup>(


### PR DESCRIPTION
## Details

Use proper value of the initial interest for a new equivalence group.