### PR TITLE
fix(payments): use isolated type utils namespace

### DIFF
--- a/components/ui/PaymentDialog.tsx
+++ b/components/ui/PaymentDialog.tsx
@@ -5,7 +5,7 @@ import { Field, Form, Formik, useFormikContext } from 'formik';
 import { TextField } from 'formik-mui';
 
 import { PaymentTypeDropdown } from './PaymentTypeDropdown';
-import { IPaymentType } from '../../interfaces/payment-type';
+import { IPaymentType, IPaymentTypeUtils } from '../../interfaces/payment-type';
 import { PaymentAttributes } from './PaymentAttributes';
 import { PaymentValidationSchema } from '../../validation-schemas/payment';
 import { SpecificPaymentGroupPaymentsValidationSchema } from '../../validation-schemas/payment-group';
@@ -83,7 +83,7 @@ export const PaymentDialog: FC<Props> = (props) => {
         }
       >
         {({ values: { type: typeString }, submitForm, isSubmitting }) => {
-          const type = IPaymentType.parse(typeString ?? '');
+          const type = IPaymentTypeUtils.parse(typeString ?? '');
           return (
             <Form>
               <Box

--- a/components/ui/PaymentTypeDropdown.tsx
+++ b/components/ui/PaymentTypeDropdown.tsx
@@ -3,7 +3,7 @@ import { FC, useMemo } from 'react';
 import { FormControl, FormHelperText, InputLabel, MenuItem, Select } from '@mui/material';
 import { useField, useFormikContext } from 'formik';
 
-import { IPaymentType } from '../../interfaces/payment-type';
+import { IPaymentTypeUtils } from '../../interfaces/payment-type';
 
 const labelId: string = 'payment-type-dropdown-label';
 
@@ -42,13 +42,13 @@ export const PaymentTypeDropdown: FC<PaymentTypeDropdownProps> = (props) => {
         label={label}
       >
         {
-          IPaymentType.VALUES.map(
+          IPaymentTypeUtils.VALUES.map(
             (type) => (
               <MenuItem
                 key={type}
                 value={type}
               >
-                {IPaymentType.getLabel(type)}
+                {IPaymentTypeUtils.getLabel(type)}
               </MenuItem>
             ),
           )

--- a/database/models/payment.ts
+++ b/database/models/payment.ts
@@ -1,6 +1,6 @@
 import { prop, modelOptions } from '@typegoose/typegoose';
 
-import { IPaymentType } from '../../interfaces/payment-type';
+import { IPaymentType, IPaymentTypeUtils } from '../../interfaces/payment-type';
 
 @modelOptions({
   schemaOptions: {
@@ -25,7 +25,7 @@ export class Payment {
   @prop({
     required: true,
     type: String,
-    enum: IPaymentType.VALUES,
+    enum: IPaymentTypeUtils.VALUES,
   })
   readonly type!: typeof IPaymentType;
 }

--- a/interfaces/payment-type.ts
+++ b/interfaces/payment-type.ts
@@ -3,7 +3,7 @@ export enum IPaymentType {
   uniformSeries = 'uniform-series',
 }
 
-export namespace IPaymentType {
+export namespace IPaymentTypeUtils {
   export const VALUES: (IPaymentType[]) = Object.values(IPaymentType) as IPaymentType[];
 
   export function parse(s: string): (IPaymentType | null) {


### PR DESCRIPTION
## Details

Avoid naming collisions by using a different namespace.