### PR TITLE
fix(auth): disable slow Google provider

### DIFF
--- a/pages/api/auth/[...nextauth].tsx
+++ b/pages/api/auth/[...nextauth].tsx
@@ -15,10 +15,10 @@ export const authOptions: NextAuthOptions = {
       clientId: github.clientId,
       clientSecret: github.clientSecret,
     }),
-    GoogleProvider({
-      clientId: google.clientId,
-      clientSecret: google.clientSecret,
-    }),
+    // GoogleProvider({
+    //   clientId: google.clientId,
+    //   clientSecret: google.clientSecret,
+    // }),
   ],
   callbacks: {
     async session({ session, token, user }) {


### PR DESCRIPTION
## Details

Disable Google as auth provider since it takes too much time to load.